### PR TITLE
Adds clickthrough support

### DIFF
--- a/src/lib/vast.js
+++ b/src/lib/vast.js
@@ -1,4 +1,5 @@
 import MediaFiles from './vast_elements/media_files'
+import Clickthrough from './vast_elements/clickthrough'
 
 export default class Vast {
   constructor({xml, url} = {}) {
@@ -12,7 +13,8 @@ export default class Vast {
     }
 
     this.loadedElements = {
-      'MediaFiles': (new MediaFiles(this))
+      'MediaFiles': (new MediaFiles(this)),
+      'Clickthrough': (new Clickthrough(this))
     }
 
     this.parse()
@@ -25,6 +27,10 @@ export default class Vast {
 
   asHLSUrl() {
     return this.loadedElements['MediaFiles'].asHLSUrl();
+  }
+
+  clickthroughUrl() {
+    return this.loadedElements['Clickthrough'].clickthroughUrl();
   }
 
   /// private ----

--- a/src/lib/vast_elements/clickthrough.js
+++ b/src/lib/vast_elements/clickthrough.js
@@ -1,0 +1,21 @@
+import VastElementBase from './vast_element_base'
+
+export default class Clickthrough extends VastElementBase {
+  setup() {
+    this.clickthrough = null
+  }
+
+  static selector() {
+    return 'Creative VideoClicks ClickThrough'
+  }
+
+  processed(){
+    this.clickthrough = this.elements.map(el => {
+      return el.childNodes[0].nodeValue
+    })[0]
+  }
+
+  clickthroughUrl() {
+    return this.clickthrough
+  }
+}

--- a/test/vast.spec.js
+++ b/test/vast.spec.js
@@ -21,7 +21,7 @@ describe('Basic Vast class functions', () => {
     const vast = new Vast({ xml: xmlString })
     vast.parse();
   })
-});
+})
 
 describe('Vast Videos', () => {
   let xmlString
@@ -36,4 +36,19 @@ describe('Vast Videos', () => {
     expect(videos.length).toBe(10);
   })
 
-});
+})
+
+describe('Vast Clickthrough', () => {
+  let xmlString
+
+  beforeAll(()=> {
+    xmlString = fs.readFileSync('./test/fixtures/vast.xml')
+  })
+
+  it('should return a click through', () => {
+    const vast = new Vast({xml: xmlString})
+    expect(vast.clickthroughUrl()).toMatch(/^https:/)
+    expect(vast.clickthroughUrl()).toBe('https://adclick.g.doubleclick.net/pcs/click?xai=AKAOjsu6OYO6ScslHz6Ie0kqub5FCVUAxcJO1oOJ8eLjzG_onZ5wMdGPn-HE7YryuBvxvcekq_rLQrDY-aOhipXfK-hErA&sig=Cg0ArKJSzLIFAUkswSyTEAE&urlfix=1&adurl=https://nfl.demdex.net/event%3Fd_event%3Dclick%26d_adsrc%3D27510%26d_bu%3D901%26d_src%3D27511%26d_site%3D1106053%26d_campaign%3D21643693%26d_rd%3Dhttp://www.nfl.com')
+  })
+})
+


### PR DESCRIPTION
Pretty straightforward. This supports the function `clickthroughUrl()`  to get the Vast click through URL

```js
const v = new Vast("some url")
v.clickthroughUrl()
```