### PR TITLE
Webpack is a dev only dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
     "jest-junit": "^6.2.1",
     "prettier": "1.16.4",
     "pretty-quick": "^1.10.0",
+    "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.0"
-  },
-  "dependencies": {
-    "webpack": "^4.29.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Thank you @jplhomer, accidentally made webpack a dependency, when it should have been a dev-only dependency.

