### PR TITLE
Removes Unused HLS test code

### DIFF
--- a/src/lib/vast.js
+++ b/src/lib/vast.js
@@ -49,10 +49,6 @@ export default class Vast {
     return this.loadedElements['MediaFiles'].videos();
   }
 
-  asHLSUrl() {
-    return this.loadedElements['MediaFiles'].asHLSUrl();
-  }
-
   clickthroughUrl() {
     return this.loadedElements['Clickthrough'].clickthroughUrl();
   }

--- a/src/lib/vast_elements/media_files.js
+++ b/src/lib/vast_elements/media_files.js
@@ -26,46 +26,9 @@ class MediaFile {
     return NodeValue.fromElement(this.element);
   }
 
-  codec() {
-    switch (this.mimeType()) {
-      case 'video/mp4':
-      case 'video/3gpp':
-        return 'mp4v';
-        break;
-      case 'video/webm':
-        return 'vp8';
-        break;
-      default:
-        throw TypeError('Unknown mime type ' + this.mimeType());
-    }
-  }
-
   isVideoType() {
     return this.mimeType().match(/^video\//);
   }
-}
-
-//
-class HlsMasterPlaylistFile {
-  constructor(videos = []) {
-    this.videos = videos;
-  }
-
-  contents() {
-    let contents = [];
-    contents.push('#EXTM3U');
-
-    contents = [
-      contents,
-      ...this.videos.map(v => {
-        return `#EXT-X-STREAM-INF:BANDWIDTH=${v.bitrate() *
-          1024},RESOLUTION=${v.width()}x${v.height()},CODEC=${v.codec()}\n${v.url()}`;
-      }),
-    ];
-
-    return contents.join('\n');
-  }
-  // ----
 }
 
 export default class MediaFiles extends VastElementBase {
@@ -92,10 +55,5 @@ export default class MediaFiles extends VastElementBase {
     return this.mediaFiles.filter(v => {
       return v.isVideoType();
     });
-  }
-
-  asHLSUrl() {
-    const hlsMaker = new HlsMasterPlaylistFile(this.videos());
-    return 'data:application/x-mpegURL;base64,' + btoa(hlsMaker.contents());
   }
 }

--- a/test/vast_elements/media_files.spec.js
+++ b/test/vast_elements/media_files.spec.js
@@ -49,27 +49,3 @@ describe('Media Files extension', () => {
     expect(video.width()).toBe(640);
   });
 });
-
-describe('MediaFile to HLS Url', () => {
-  let xmlString;
-  let vast;
-
-  beforeAll(() => {
-    xmlString = fs.readFileSync('./test/fixtures/vast.xml');
-    vast = new Vast({ xml: xmlString });
-  });
-
-  it('should return a data url', () => {
-    expect(vast.asHLSUrl()).toBeDefined();
-    expect(vast.asHLSUrl()).toMatch(/^data:application\/x-mpegURL/);
-  });
-
-  it('should conform to m3u8 headers', () => {
-    const dataUrl = vast.asHLSUrl();
-    const contents = atob(dataUrl.split(',')[1]);
-    expect(contents).toMatch(/^#EXTM3U/);
-    const contentArrayAsLines = contents.split('\n');
-    expect(contentArrayAsLines[1]).toBe('#EXT-X-STREAM-INF:BANDWIDTH=268288,RESOLUTION=640x360,CODEC=mp4v');
-    expect(contentArrayAsLines[2]).toBe(vast.videos()[0].url());
-  });
-});


### PR DESCRIPTION
Back in the very first release #1  of this code, we were hoping we could create an in-memory HLS playlist and let the browser's native playback code do all of the bandwidth and size stream decisioning. 

That didn't work, yet the code remained. This removes that old unused code.

![](https://media.tenor.com/images/82f497b36ac14b67dfac665296597ce4/tenor.gif)