### PR TITLE
Releasing version 1.3.0 for open source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.0 (April 1st, 2019)
+
+- Open Sourced
+
 ## v1.2.1 (March 19, 2019)
 
 - Support for autplay and mute options in applications functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concert-vast",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Simple Vast Parsing for Concert Video Ads",
   "main": "src/index.js",
   "author": "Vox Media",


### PR DESCRIPTION
This is a simple version bump to 1.3.0 now as an open sourced thing.