### PR TITLE
update: bump actions/cache version and update changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.3 (January 27, 2025)
+
+- Update actions/cache version to v4 in ci action
+
 ## v1.3.2 (August 29, 2023)
 
 - Add HLS support for VAST videos

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voxmedia/concert-vast",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Simple Vast Parsing for Concert Video Ads",
   "main": "dist/concert-vast.js",
   "author": "Vox Media",


### PR DESCRIPTION
> Github is deprecating actions/cache@v1 and actions/cache@v2 on Feb 1, 2025. After this date, any workflow that uses this action will fail. To avoid these workflows from failing, update the action to use v3 or v4.

This PR bumps the actions cache version to v4.